### PR TITLE
Added Patricia Trie structures for quering Students and Ads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.11
+FROM python:3.8
 
 ENV PYTHONUNBUFFERED=1
 

--- a/data_logic/ptrie_structures.py
+++ b/data_logic/ptrie_structures.py
@@ -1,0 +1,130 @@
+from collections.abc import MutableMapping
+from pytrie import StringTrie
+
+
+class StudentPTrie:
+    """
+    A class used to represent a Patricia Trie for Students
+
+    ...
+
+    Attributes
+    ----------
+    trie : StringTrie
+        a Patricia Trie for storing student data
+
+    Methods
+    -------
+    add_student(forename, lastname, student):
+        Adds a student to the trie.
+    remove_student(forename, lastname):
+        Removes a student from the trie.
+    search(string):
+        Returns a list of students whose name matches the search string.
+    """
+
+    def __init__(self):
+        """Initializes the StudentTrie with an empty Patricia Trie."""
+        self.trie = StringTrie()
+
+    def add_student(self, student):
+        """
+        Adds a student to the trie.
+
+        Parameters:
+        student (obj): The student object.
+        """
+        self.trie[student.forename.lower()] = student
+        self.trie[student.surname.lower()] = student
+        self.trie[student.email.lower()] = student
+
+    def remove_student(self, student):
+        """
+        Removes a student from the trie.
+
+        Parameters:
+        forename (str): The forename of the student.
+        lastname (str): The lastname of the student.
+        """
+        del self.trie[student.forename.lower()]
+        del self.trie[student.surname.lower()]
+        del self.trie[student.email.lower()]
+
+    def search(self, string):
+        """
+        Returns a list of students whose name matches the search string.
+
+        Parameters:
+        string (str): The search string.
+
+        Returns:
+        list: A list of students whose name matches the search string.
+        """
+        # TODO: remove duplicates from result list
+        return list(self.trie.values(prefix=string.lower()))[:10]
+
+
+class AdsPTrie:
+    """
+    A class used to represent a Patricia Trie for Ads
+
+    ...
+
+    Attributes
+    ----------
+    trie : StringTrie
+        a Patricia Trie for storing ad data
+
+    Methods
+    -------
+    add_ad(title, ad):
+        Adds an ad to the trie.
+    remove_ad(title):
+        Removes an ad from the trie.
+    search(string):
+        Returns a list of ads whose title matches the search string.
+    """
+
+    def __init__(self):
+        """Initializes the AdsTrie with an empty Patricia Trie."""
+        self.trie = StringTrie()
+
+    def add_ad(self, title, ad):
+        """
+        Adds an ad to the trie.
+
+        Parameters:
+        title (str): The title of the ad.
+        ad (obj): The ad object.
+        """
+        self.trie[title.lower()] = ad
+
+    def remove_ad(self, title):
+        """
+        Removes an ad from the trie.
+
+        Parameters:
+        title (str): The title of the ad.
+        """
+        del self.trie[title.lower()]
+
+    def search(self, string):
+        """
+        Returns a list of ads whose title matches the search string.
+
+        Parameters:
+        string (str): The search string.
+
+        Returns:
+        list: A list of ads whose title matches the search string.
+        """
+        return list(self.trie.values(prefix=string.lower()))[:10]
+
+
+""" 
+Define the trie structures for the student and ad models
+TODO: Implement persistence for the trie structures
+"""
+
+student_ptrie = StudentPTrie()
+ads_ptrie = AdsPTrie()

--- a/data_logic/util.py
+++ b/data_logic/util.py
@@ -70,7 +70,6 @@ def decode_jwt(request):
         raise AuthenticationFailed('Invalid token')
 
     try:
-        return Student.nodes.get(
-            email=payload['sub'])
+        return Student.nodes.get(email=payload['sub'])
     except Student.DoesNotExist:
         raise Student.DoesNotExist

--- a/omnistudyin_backend/urls.py
+++ b/omnistudyin_backend/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path('get_session_student/', get_session_student, name='get_student'),
     path('get_all_students/', get_all_students, name='get_all_students'),
     path('delete_session_student/', delete_session_student, name='delete_student'),
+    path('query_students/', query_students, name='query_students'),
     # Ad_group
     path('create_adgroup/', create_ad_group, name='adgroup'),
     path('get_adgroups/', get_ad_groups, name='get_adgroups'),
@@ -44,8 +45,7 @@ urlpatterns = [
     path('change_ad_in_group/', change_ad_in_group, name='change_ad'),
     path('delete_ad_in_group/', delete_ad_in_group, name='delete_ad'),
     # search
-    path('search_ads/', search_ads, name='search'),
-    path('search_students/', search_students, name='search_students'),
+    path('query_ads/', query_ads, name='query_ads'),
     path('search_adgroups/', search_ad_groups, name='search_adgroups'),
     path('search_all/', search_all, name='search_all'),
     path('search_ads_by_group/', search_ads_by_group, name='search_ad_in_group'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ neomodel==5.2.1
 argon2-cffi==20.1.0
 better_profanity==0.7.0
 PyJWT==2.3.0
+pytrie==0.3.1
 


### PR DESCRIPTION
Ich habe jetzt mal die neue Suchfunktionalität hinzugefügt. Anstatt nun für die Suche von Studenten (per Vorname, Nachname oder Email) oder Ads (per Titel) immer jeweils den gesamten Datensatz zu durchlaufen, habe ich die Datenstruktur "Patricia Trie" genutzt. https://de.wikipedia.org/wiki/Patricia-Trie# ... Dadurch sucht man sehr effizient die Matches finden!
Dafür musste ich die Python Version von 3.11 auf 3.8 setzen, damit das Modul verfügbar ist. Hat aber keine Schäden verursacht.

Immer, wenn jetzt ein neuer Student oder eine neue Ad hinzugefügt wird, muss diese(r) in den Trie eingepflegt werden. @sk1ldpadde Ich habe es für den Studenten schon gemacht, gib mir mal kurz Rückmeldung, ob ich es auch für die Ads machen soll, oder ob du es noch machst. Für die Suche der Ads habe ich es aber schon eingefügt.

@Vanilla-1311 @ultimatemandy Im Frontend könnt ihr nun also eine Suchleiste einfügen, mit der Studenten und Ads gesucht werden können. Ich habe die Query-Liste auf max. 10 Elemente beschränkt. Dazu müsst ihr einfach den Query-String an den Endpoint "query_students/" oder "query_ads/" senden. In der Antwort erhaltet ihr die Instanzen, die gefunden wurde. Ihr müsst das immer dann neu aufrufen, wenn der Nutzer ein Zeichen hinzufügt oder löscht, damit es real-time reaktiv ist, so wie in den klassischen Apps auch.